### PR TITLE
Fix :: cant change activity name  [MOWAZI-30]

### DIFF
--- a/wp-content/themes/mowazi/navs/nav-post.php
+++ b/wp-content/themes/mowazi/navs/nav-post.php
@@ -28,7 +28,7 @@ if (!$post_title) {
 
                 <div class="container-post__center">
                     <div class="form-group form-group_alt_post">
-                      <input type="text" value="<?php echo $post_title; ?>" name="title" class="form-control" placeholder="العنوان">
+                      <input type="text" value="<?php echo $post_title; ?>" name="title" class="form-control" placeholder="العنوان" disabled>
                     </div>
                 </div>
 


### PR DESCRIPTION
while creating an activity on the editor page, if i type in the name field and change the name, it will not take effect , so i disabled the input in the edit page and when click on انشر you can edit the name.

Steps:
    click ‘edit’ on any content on your page

    click on the ‘name’ field in the top of the page

    type new name

    click save and preview

Expected Result:

name to change


Actual Result:
input disabled and you can change the name in the input after clicking on انشر